### PR TITLE
Fix "make build" errors by adding more specific base image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,23 @@ You'll want to these packages for running and testing the full codebase
 1. Install docker and docker-compose
 2. Build ACE framework by running
 ```shell
-git clone http://github.com/usnistgov/ace.git
+git clone https://github.com/jhamilt5/ACE.git -b feature-macos
 cd ace
-bash build.sh
+make cpu_nist-ace_extra  # creates the images "datamachines/nist-ace:demo", "ocv-ssd:demo", "ace-test-analytic:demo", "act-recognition:demo", and "camera_stream:demo"
 ```
 3. Build ACE-UI by running 
 ```shell
 cd ../
-git clone https://github.com/usnistgov/ace-ui.git
-cd ../ace-ui
+git clone https://github.com/jhamilt5/ace-ui.git -b bugfix/fix-make-build-step
+cd ace-ui
 make build
 ```
-4. start the application run `make start`
+4. Start the application by running
+```shell
+make start
+```
 5. Using a web browser, go to this URL  http://localhost:8999/app/ to access the ACE UI
+6. You can now jump to the README section "Using public video streams" if you'd like
 
 
 ### Makefile shortcuts

--- a/contrib/video_server/Dockerfile
+++ b/contrib/video_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:buster
+FROM python:3.10.0-buster
 RUN apt-get update
 RUN apt-get install ffmpeg libsm6 libxext6  -y
 WORKDIR /usr/src/app

--- a/contrib/video_server/requirements.txt
+++ b/contrib/video_server/requirements.txt
@@ -1,1 +1,1 @@
-opencv_python==4.5.1.48
+opencv_python==4.5.4.58

--- a/web-app/Dockerfile
+++ b/web-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-buster-slim
+FROM node:14.18-buster-slim
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
When running the `make build` step for the `ace-ui` component (after the `ace` docker image has been made), there were errors for both the `video_server` and `web-app` docker images. 

The `video_server` could not install the specific version of `opencv_python` with `pip` because its `numpy` dependency no longer worked for Python version 3.10.0, which is the current default for the `python:buster` image. To remedy, the `opencv_python` version was updated to the current latest (4.5.4.58) and also pinned the base docker image to Python version 3.10.0

The `web-app` docker image was failing to build because the current version of `node` in the base Docker image `node:buser-slim` is 17.0.1, but the `npm build` requires version 14.18. That node version is now pinned in the base image for the `web-app` Dockerfile.